### PR TITLE
2.0.0 release

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,3 +1,0 @@
-# Default ignored files
-/shelf/
-/workspace.xml

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <dependency>
             <groupId>com.eficode</groupId>
             <artifactId>devstack</artifactId>
-            <version>2.3.2-SNAPSHOT</version>
+            <version>2.3.5-SNAPSHOT</version>
             <classifier>standalone</classifier>
             <scope>test</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,15 @@
             <scope>test</scope>
         </dependency>
 
+        <!-- https://mvnrepository.com/artifact/org.apache.commons/commons-text -->
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
+            <version>1.10.0</version>
+            <scope>test</scope>
+        </dependency>
+
+
         <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-all</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.eficode.atlassian</groupId>
     <artifactId>jirainstancemanager</artifactId>
-    <version>1.5.2-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <description>A groovy library for interacting with Jira REST API.</description>
 
     <profiles>
@@ -55,7 +55,7 @@
         <dependency>
             <groupId>com.konghq</groupId>
             <artifactId>unirest-java</artifactId>
-            <version>3.14.0</version>
+            <version>3.14.2</version>
             <classifier>standalone</classifier>
         </dependency>
         <dependency>
@@ -67,7 +67,7 @@
         <dependency>
             <groupId>com.eficode</groupId>
             <artifactId>devstack</artifactId>
-            <version>2.2.0-SNAPSHOT-groovy-${groovy.version}</version>
+            <version>2.3.2-SNAPSHOT</version>
             <classifier>standalone</classifier>
             <scope>test</scope>
         </dependency>
@@ -82,6 +82,12 @@
         <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-xml</artifactId>
+            <version>[3.0,4.0)</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy-json</artifactId>
             <version>[3.0,4.0)</version>
             <scope>provided</scope>
         </dependency>
@@ -112,6 +118,47 @@
             <version>2.5.1</version>
             <scope>provided</scope>
         </dependency>
+
+
+
+        <!-- https://mvnrepository.com/artifact/com.atlassian.jira/jira-api -->
+        <dependency>
+            <groupId>com.atlassian.jira</groupId>
+            <artifactId>jira-api</artifactId>
+            <version>9.7.0</version>
+            <scope>compile</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.atlassian.jira</groupId>
+            <artifactId>jira-core</artifactId>
+            <version>9.7.0</version>
+            <scope>compile</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.atlassian.plugins</groupId>
+            <artifactId>atlassian-plugins-api</artifactId>
+            <version>7.1.4</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.reflections</groupId>
+            <artifactId>reflections</artifactId>
+            <version>0.10.2</version>
+        </dependency>
+
+
     </dependencies>
 
     <distributionManagement>
@@ -123,6 +170,10 @@
     </distributionManagement>
 
     <repositories>
+        <repository>
+            <id>Atlassian-External</id>
+            <url>https://packages.atlassian.com/mvn/maven-atlassian-external/</url>
+        </repository>
         <repository>
             <id>eficode-github-insightManager</id>
             <url>https://github.com/eficode/devStack/raw/packages/repository/</url>

--- a/src/main/groovy/com/eficode/atlassian/jiraInstanceManager/JiraInstanceManagerRest.groovy
+++ b/src/main/groovy/com/eficode/atlassian/jiraInstanceManager/JiraInstanceManagerRest.groovy
@@ -158,7 +158,7 @@ final class JiraInstanceManagerRest {
 
         UnirestInstance unirestInstance = Unirest.spawnInstance()
         unirestInstance.config().followRedirects(false).defaultBaseUrl(baseUrl).verifySsl(verifySsl)
-        if (unirest.config().proxy.host) {
+        if (unirest.config().proxy?.host) {
             unirestInstance.config().proxy(unirest.config().proxy.host, unirest.config().proxy.port)
         }
 
@@ -258,7 +258,7 @@ final class JiraInstanceManagerRest {
         if (username && password) {
             getRequest.basicAuth(username, password)
         }
-        if (unirest.config().proxy.host) {
+        if (unirest.config().proxy?.host) {
             unirestInstance.config().proxy(unirest.config().proxy.host, unirest.config().proxy.port)
         }
 
@@ -576,6 +576,18 @@ final class JiraInstanceManagerRest {
 
         return MarketplaceApp.searchMarketplace(text, hosting)
 
+    }
+
+    /**
+     * A helper method for installing ScriptRunner DataCenter
+     * If SR is already installed but of a different version, it will be uninstalled and replaced with the
+     * correct version
+     * @param licence License key for ScriptRunner to use
+     * @param versionNr The versions to use, defaults to "latest"
+     * @return The JiraApp representation of the installed SR
+     */
+    JiraApp installScriptRunner(String licence, String versionNr = "latest"){
+        return MarketplaceApp.installScriptRunner(this, licence, versionNr)
     }
 
 

--- a/src/main/groovy/com/eficode/atlassian/jiraInstanceManager/beans/AssetFieldBean.groovy
+++ b/src/main/groovy/com/eficode/atlassian/jiraInstanceManager/beans/AssetFieldBean.groovy
@@ -1,0 +1,26 @@
+package com.eficode.atlassian.jiraInstanceManager.beans
+
+import kong.unirest.HttpResponse
+
+class AssetFieldBean extends FieldBean {
+
+
+    /*
+    ArrayList<Long> getConfigSchemeIds() {
+
+        HttpResponse<Map> rawResponse = jiraInstance.unirest.get("/rest/assets/1.0/customfield/default/configscheme/" + numericId)
+                .cookie(jiraInstance.acquireWebSudoCookies())
+                .asObject(Map)
+
+        assert rawResponse.status == 200 : "Error config schemeIDs for assets field:" + id
+        assert rawResponse.body.containsKey("configurationSchemeIds")
+
+        return rawResponse.body.configurationSchemeIds as ArrayList<Long>
+
+    }
+
+     */
+
+
+
+}

--- a/src/main/groovy/com/eficode/atlassian/jiraInstanceManager/beans/AssetFieldBean.groovy
+++ b/src/main/groovy/com/eficode/atlassian/jiraInstanceManager/beans/AssetFieldBean.groovy
@@ -5,7 +5,7 @@ import kong.unirest.HttpResponse
 class AssetFieldBean extends FieldBean {
 
 
-    /*
+
     ArrayList<Long> getConfigSchemeIds() {
 
         HttpResponse<Map> rawResponse = jiraInstance.unirest.get("/rest/assets/1.0/customfield/default/configscheme/" + numericId)
@@ -19,7 +19,7 @@ class AssetFieldBean extends FieldBean {
 
     }
 
-     */
+
 
 
 

--- a/src/main/groovy/com/eficode/atlassian/jiraInstanceManager/beans/FieldBean.groovy
+++ b/src/main/groovy/com/eficode/atlassian/jiraInstanceManager/beans/FieldBean.groovy
@@ -1,0 +1,376 @@
+package com.eficode.atlassian.jiraInstanceManager.beans
+
+
+import com.eficode.atlassian.jiraInstanceManager.JiraInstanceManagerRest
+import com.fasterxml.jackson.annotation.JsonAnyGetter
+import com.fasterxml.jackson.annotation.JsonAnySetter
+import com.fasterxml.jackson.annotation.JsonIgnore
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.databind.ObjectMapper
+import kong.unirest.GenericType
+import kong.unirest.HttpResponse
+import kong.unirest.UnirestInstance
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+
+class FieldBean {
+
+    static Logger log = LoggerFactory.getLogger(FieldBean.class)
+    static final ObjectMapper objectMapper = new ObjectMapper()
+
+
+    @JsonProperty("id")
+    String id
+    @JsonProperty("name")
+    String name
+    @JsonProperty("custom")
+    Boolean custom
+    @JsonProperty("orderable")
+    Boolean orderable
+    @JsonProperty("navigable")
+    Boolean navigable
+    @JsonProperty("searchable")
+    Boolean searchable
+    @JsonProperty("clauseNames")
+    List<String> clauseNames
+    @JsonProperty("schema")
+    FieldSchema schema
+    @JsonIgnore()
+    JiraInstanceManagerRest jiraInstance
+    @JsonIgnore
+    Map<String, Object> additionalProperties = [:]
+
+
+    static class FieldSchema {
+
+        @JsonProperty("type")
+        String type
+        @JsonProperty("system")
+        String system
+        @JsonProperty("items")
+        String items
+        @JsonProperty("custom")
+        public String custom;
+        @JsonProperty("customId")
+        public Integer customId;
+        @JsonIgnore
+        private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>()
+
+        @JsonAnyGetter
+        Map<String, Object> getAdditionalProperties() {
+            return this.additionalProperties
+        }
+
+        @JsonAnySetter
+        void setAdditionalProperty(String name, Object value) {
+            this.additionalProperties.put(name, value)
+        }
+
+    }
+
+
+    static class FieldType {
+
+        @JsonProperty("name")
+        public String name;
+        @JsonProperty("description")
+        public String description;
+        @JsonProperty("key")
+        public String key;
+        @JsonProperty("previewImageUrl")
+        public String previewImageUrl;
+        @JsonProperty("categories")
+        public List<String> categories;
+        @JsonProperty("options")
+        public Boolean options;
+        @JsonProperty("cascading")
+        public Boolean cascading;
+        @JsonProperty("searchers")
+        public List<String> searchers;
+        @JsonProperty("isManaged")
+        public Boolean isManaged;
+        @JsonIgnore
+        private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
+
+        @JsonAnyGetter
+        Map<String, Object> getAdditionalProperties() {
+            return this.additionalProperties;
+        }
+
+        @JsonAnySetter
+        public void setAdditionalProperty(String name, Object value) {
+            this.additionalProperties.put(name, value);
+        }
+
+
+        static FieldType fromMap(Map rawMap) {
+            FieldType fieldType = objectMapper.convertValue(rawMap, FieldType.class)
+
+            return fieldType
+        }
+
+
+        static ArrayList<FieldType> getFieldTypes(JiraInstanceManagerRest jim) {
+
+            ArrayList<FieldType> types = []
+
+            try {
+                HttpResponse<Map> rawResponse = jim.unirest.get("/rest/globalconfig/1/customfieldtypes")
+                        .cookie(jim.acquireWebSudoCookies())
+                        .asObject(new GenericType<Map>() {})
+
+
+                types = rawResponse.body.types.collect { fromMap(it as Map) }
+            } catch (ex) {
+
+
+                log.error("Error getting JIRA Fields Type:" + ex.message)
+                throw ex
+            }
+
+
+            return types
+
+        }
+    }
+
+
+    @JsonAnyGetter
+    Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties
+    }
+
+    @JsonAnySetter
+    void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value)
+    }
+
+
+    String toString() {
+        return name + " (${id}) - ${schema?.type?.capitalize()}" + (schema?.type == "array" ? "<${schema?.items}>" : "")
+    }
+
+    Long getNumericId() {
+        return id.replace("customfield_", "").toLong()
+    }
+
+    static FieldBean fromMap(Map rawMap, JiraInstanceManagerRest jim) {
+        FieldBean jiraFieldBean
+
+        if (rawMap.custom && rawMap?.schema?.custom?.contains("com.riadalabs.jira.plugins.insight")) {
+            jiraFieldBean = objectMapper.convertValue(rawMap, AssetFieldBean.class)
+        } else {
+            jiraFieldBean = objectMapper.convertValue(rawMap, FieldBean.class)
+        }
+
+        jiraFieldBean.jiraInstance = jim
+
+        return jiraFieldBean
+    }
+
+    FieldType getFieldType(boolean useCache = true) {
+
+
+        if (!custom) {
+            FieldType systemType = new FieldType()
+            systemType.with { [name: name, id: id] }
+            return systemType
+        } else {
+
+            return jiraInstance.getFieldTypes(useCache).find { it.key == schema.custom }
+        }
+
+    }
+
+
+    /**
+     * Get projects that the field has been applied to
+     * Returns all project if it´s a globally applied field
+     * @param useCache use cached information if set ot true
+     * @return
+     */
+    ArrayList<ProjectBean> getFieldProjects(boolean useCache = true) {
+
+        if (!custom) {
+            //Return all projects if its not a custom field
+            jiraInstance.getProjects(useCache)
+        } else {
+
+            try {
+
+                ArrayList<Map> rawResponse = jiraInstance.getJsonPages("/rest/api/2/customFields", [search: name], "values")
+                Map rawField = rawResponse.find { it.id == id }
+                assert !rawField.isEmpty(): "Error finding customfield $id"
+
+                if (rawField.isAllProjects) {
+                    //Return all projects if global
+                    return jiraInstance.getProjects()
+                }
+                ArrayList<Double> fieldProjectIds = rawField.projectIds as ArrayList<Double>
+                ArrayList<ProjectBean> projectBeans = jiraInstance.getProjects(useCache).findAll {
+                    it.projectId.toDouble() in fieldProjectIds
+                }
+
+                return projectBeans
+            } catch (ex) {
+
+
+                log.error("Error getting projects for JIRA Field (${toString()}):" + ex.message)
+                throw ex
+            }
+
+        }
+
+    }
+
+
+    /**
+     * Get issue types that the field has been explicitly applied to
+     * @param useCache use cached information if set ot true
+     * @return
+     */
+    ArrayList<IssueTypeBean> getFieldIssueTypes(boolean useCache = true) {
+
+        if (!custom) {
+            //Return all projects if its not a custom field
+            jiraInstance.getIssueTypes(useCache)
+        } else {
+
+            try {
+
+                ArrayList<Map> rawResponse = jiraInstance.getJsonPages("/rest/api/2/customFields", [search: name], "values")
+                Map rawField = rawResponse.find { it.id == id }
+                assert !rawField.isEmpty(): "Error finding customfield $id"
+
+                ArrayList<IssueTypeBean> instanceIssueTypes = jiraInstance.getIssueTypes(useCache)
+
+                if (rawField.issueTypeIds == []) {
+                    //Return all issue types if global
+                    return instanceIssueTypes
+                }
+                ArrayList<String> fieldIssueTypeIds = rawField.issueTypeIds as ArrayList<String>
+                ArrayList<IssueTypeBean> issueTypeBeans = instanceIssueTypes.findAll {
+                    it.id in fieldIssueTypeIds
+                }
+
+                return issueTypeBeans
+            } catch (ex) {
+
+
+                log.error("Error getting projects for JIRA Field (${toString()}):" + ex.message)
+                throw ex
+            }
+
+        }
+
+    }
+
+
+    /**
+     * Get all fields (custom and system) in instance
+     * @param jim The instance to fetch fields from
+     * @return an array of JiraFieldBeans
+     */
+    static ArrayList<FieldBean> getFields(JiraInstanceManagerRest jim) {
+
+        UnirestInstance unirest = jim.getUnirest()
+        ArrayList<FieldBean> fields
+
+        try {
+
+            HttpResponse<ArrayList<Map>> rawResponse = unirest.get("/rest/api/2/field")
+                    .cookie(jim.acquireWebSudoCookies())
+                    .asObject(new GenericType<ArrayList<Map>>() {})
+
+            fields = rawResponse.body.collect { fromMap(it, jim) }
+
+
+        } catch (ex) {
+
+
+            log.error("Error getting JIRA Fields:" + ex.message)
+            throw ex
+        }
+
+
+        return fields
+
+    }
+
+
+    /**
+     * Create a new JIRA Customfield field
+     * @param jim The instance where the field should be created
+     * @param name Name of the new field
+     * @param description (Optional) Description of the new field
+     * @param searcherKey The key of the searcher to use, can be found using getFieldTypesInInstance()
+     * @param typeKey The key of the type to use, can be found using getFieldTypesInInstance()
+     * @param projectIds The projects to apply to, set to [] for all
+     * @param issueTypeIds The IDs to apply to, set to [-1] for all
+     * @return a new FieldBean
+     */
+    static FieldBean createCustomfield(JiraInstanceManagerRest jim, String name, String searcherKey, String typeKey, String description = "", ArrayList<String> projectIds = [], ArrayList<String> issueTypeIds = ["-1"]) {
+
+        UnirestInstance unirest = jim.getUnirest()
+
+        try {
+            HttpResponse<Map> rawResponse = unirest.post("/rest/api/2/field")
+                    .cookie(jim.acquireWebSudoCookies())
+                    .contentType("application/json")
+                    .body([
+                            name        : name,
+                            description : description,
+                            searcherKey : searcherKey,
+                            type        : typeKey,
+                            projectIds  : projectIds,
+                            issueTypeIds: issueTypeIds
+
+                    ])
+                    .asObject(Map)
+
+            assert rawResponse.status == 201: "API returned unexpected status code when creating field:" + rawResponse.status
+            FieldBean newFieldBean = getFields(jim).find { it.id == rawResponse.body.id }
+
+            return newFieldBean
+        } catch (ex) {
+            log.error("Error creating JIRA Field ($name):" + ex.message)
+            throw ex
+        }
+
+
+    }
+
+    boolean deleteCustomField() {
+        assert custom: "Error, cant System field"
+        return deleteCustomField(jiraInstance, id)
+    }
+
+
+    static boolean deleteCustomField(JiraInstanceManagerRest jim, String fieldId) {
+
+        assert fieldId.startsWith("customfield_"): "fieldId should start with customfield_"
+
+        try {
+            HttpResponse<Map> rawResponse = jim.unirest.delete("/rest/api/2/customFields")
+                    .cookie(jim.acquireWebSudoCookies())
+                    .contentType("application/json")
+                    .queryString(
+                            [
+                                    ids: fieldId
+                            ]
+                    )
+                    .asObject(Map)
+
+            assert rawResponse.status == 200: "API returned unexpected status code when deleting field:" + rawResponse.status
+            assert rawResponse.body.deletedCustomFields == [fieldId]: "API returned unexpected body when deleting field:" + rawResponse.body
+
+            return true
+        } catch (ex) {
+            log.error("Error deleting JIRA Field ($fieldId):" + ex.message)
+            throw ex
+        }
+
+    }
+
+}

--- a/src/main/groovy/com/eficode/atlassian/jiraInstanceManager/beans/FieldBean.groovy
+++ b/src/main/groovy/com/eficode/atlassian/jiraInstanceManager/beans/FieldBean.groovy
@@ -42,6 +42,74 @@ class FieldBean {
     Map<String, Object> additionalProperties = [:]
 
 
+    static class FieldConfigurationContext {
+
+        @JsonProperty("self")
+        public String self;
+        @JsonProperty("id")
+        public Integer id;
+        @JsonProperty("name")
+        public String name;
+        @JsonProperty("description")
+        public String description;
+        @JsonProperty("field")
+        public FieldBean field;
+        @JsonProperty("allProjects")
+        public Boolean allProjects;
+        @JsonProperty("projects")
+        public List<ProjectBean> projects;
+        @JsonProperty("allIssueTypes")
+        public Boolean allIssueTypes;
+        @JsonProperty("issueTypes")
+        public List<IssueTypeBean> issueTypes;
+        @JsonIgnore()
+        JiraInstanceManagerRest jiraInstance
+        @JsonIgnore
+        private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
+
+        @JsonAnyGetter
+        public Map<String, Object> getAdditionalProperties() {
+            return this.additionalProperties;
+        }
+
+        @JsonAnySetter
+        public void setAdditionalProperty(String name, Object value) {
+            this.additionalProperties.put(name, value);
+        }
+
+
+        static ArrayList<FieldConfigurationContext> getFieldContexts(String fieldId, JiraInstanceManagerRest jim) {
+
+
+            try {
+
+                HttpResponse<ArrayList<Map>> rawResponse = jim.unirest.get("/rest/internal/2/field/$fieldId/context").asObject(new GenericType<ArrayList<Map>>() {})
+
+                assert rawResponse.status == 200 : "Error getting ConfigContext for field:" + fieldId
+
+                ArrayList<FieldConfigurationContext> contexts =  rawResponse.body.collect {FieldConfigurationContext.fromMap(it, jim)}
+
+                return contexts
+            }catch (ex) {
+                log.error("Error getting Config context for field $fieldId:" + ex.message)
+                throw ex
+            }
+
+
+        }
+
+        static FieldConfigurationContext fromMap(Map rawMap, JiraInstanceManagerRest jim) {
+            FieldConfigurationContext configContext = objectMapper.convertValue(rawMap, FieldConfigurationContext.class)
+            configContext.jiraInstance = jim
+            return configContext
+        }
+
+
+
+
+
+    }
+
     static class FieldSchema {
 
         @JsonProperty("type")
@@ -184,12 +252,15 @@ class FieldBean {
     }
 
 
+
+
     /**
      * Get projects that the field has been applied to
      * Returns all project if it´s a globally applied field
      * @param useCache use cached information if set ot true
      * @return
      */
+    /*
     ArrayList<ProjectBean> getFieldProjects(boolean useCache = true) {
 
         if (!custom) {
@@ -224,12 +295,16 @@ class FieldBean {
 
     }
 
+     */
+
+
 
     /**
      * Get issue types that the field has been explicitly applied to
      * @param useCache use cached information if set ot true
      * @return
      */
+    /*
     ArrayList<IssueTypeBean> getFieldIssueTypes(boolean useCache = true) {
 
         if (!custom) {
@@ -264,6 +339,14 @@ class FieldBean {
 
         }
 
+    }
+
+     */
+
+
+    ArrayList<FieldConfigurationContext> getFieldContexts() {
+
+        return FieldConfigurationContext.getFieldContexts(id, jiraInstance)
     }
 
 

--- a/src/main/groovy/com/eficode/atlassian/jiraInstanceManager/beans/IssueTypeBean.groovy
+++ b/src/main/groovy/com/eficode/atlassian/jiraInstanceManager/beans/IssueTypeBean.groovy
@@ -1,0 +1,75 @@
+package com.eficode.atlassian.jiraInstanceManager.beans
+
+import com.eficode.atlassian.jiraInstanceManager.JiraInstanceManagerRest
+import com.fasterxml.jackson.annotation.JsonAnyGetter
+import com.fasterxml.jackson.annotation.JsonAnySetter
+import com.fasterxml.jackson.annotation.JsonIgnore
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.databind.ObjectMapper
+import kong.unirest.GenericType
+import kong.unirest.HttpResponse
+import kong.unirest.UnirestInstance
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+class IssueTypeBean {
+
+    static Logger log = LoggerFactory.getLogger(FieldBean.class)
+    static final ObjectMapper objectMapper = new ObjectMapper()
+
+
+    @JsonProperty("self")
+    public String self;
+    @JsonProperty("id")
+    public String id;
+    @JsonProperty("description")
+    public String description;
+    @JsonProperty("iconUrl")
+    public String iconUrl;
+    @JsonProperty("name")
+    public String name;
+    @JsonProperty("subtask")
+    public Boolean subtask;
+    @JsonProperty("avatarId")
+    public Integer avatarId;
+    @JsonIgnore()
+    JiraInstanceManagerRest jiraInstance
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    static IssueTypeBean fromMap(Map rawMap, JiraInstanceManagerRest jim) {
+        IssueTypeBean issueTypeBean = objectMapper.convertValue(rawMap, IssueTypeBean.class)
+        issueTypeBean.jiraInstance = jim
+        return issueTypeBean
+    }
+
+    static ArrayList<IssueTypeBean> getIssueTypes(JiraInstanceManagerRest jim) {
+
+        UnirestInstance unirest = jim.getUnirest()
+        ArrayList<FieldBean> fields
+
+        try {
+
+            ArrayList<Map> rawResponse = jim.getJsonPages("/rest/api/2/issuetype/page", [:], "values")
+
+            return rawResponse.collect { fromMap(it, jim) }
+
+        } catch (ex) {
+
+
+            log.error("Error getting JIRA Issue Types:" + ex.message)
+            throw ex
+        }
+
+
+    }
+}

--- a/src/main/groovy/com/eficode/atlassian/jiraInstanceManager/beans/ProjectBean.groovy
+++ b/src/main/groovy/com/eficode/atlassian/jiraInstanceManager/beans/ProjectBean.groovy
@@ -1,14 +1,21 @@
 package com.eficode.atlassian.jiraInstanceManager.beans
 
+import com.fasterxml.jackson.annotation.JsonAlias
 import com.fasterxml.jackson.annotation.JsonAnyGetter
 import com.fasterxml.jackson.annotation.JsonAnySetter
 import com.fasterxml.jackson.databind.ObjectMapper
 
 class ProjectBean {
+
+    @JsonAlias(["self"])
     public String returnUrl
+    @JsonAlias(["id"])
     public Integer projectId
+    @JsonAlias(["key"])
     public String projectKey
+    @JsonAlias(["name"])
     public String projectName
+    public String projectTypeKey
     public Map remoteProjectLinks
     public Map<String, Object> unknownParameters = [:]
 

--- a/src/main/groovy/com/eficode/atlassian/jiraInstanceManager/beans/ScriptFieldBean.groovy
+++ b/src/main/groovy/com/eficode/atlassian/jiraInstanceManager/beans/ScriptFieldBean.groovy
@@ -1,0 +1,231 @@
+package com.eficode.atlassian.jiraInstanceManager.beans
+
+import com.eficode.atlassian.jiraInstanceManager.JiraInstanceManagerRest
+import com.fasterxml.jackson.annotation.JsonAlias
+import com.fasterxml.jackson.annotation.JsonAnyGetter
+import com.fasterxml.jackson.annotation.JsonAnySetter
+import com.fasterxml.jackson.annotation.JsonIgnore
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.annotation.JsonSetter
+import com.fasterxml.jackson.core.type.TypeReference
+import com.fasterxml.jackson.databind.ObjectMapper
+import kong.unirest.Cookies
+import kong.unirest.GenericType
+import kong.unirest.HttpResponse
+import kong.unirest.UnirestInstance
+import org.apache.groovy.json.internal.LazyMap
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+
+class ScriptFieldBean {
+
+    static Logger log = LoggerFactory.getLogger(FieldBean.class)
+    static final ObjectMapper objectMapper = new ObjectMapper()
+
+
+    @JsonProperty("id")
+    public String id;
+    @JsonProperty("version")
+    public Integer version;
+    @JsonProperty("ownedBy")
+    public Object ownedBy;
+    @JsonProperty("fieldConfigurationSchemeId")
+    public Integer fieldConfigurationSchemeId;
+    @JsonProperty("customFieldId")
+    public Integer customFieldId;
+    @JsonProperty("note")
+    public Object note;
+    @JsonProperty("fieldConfigSchemeName")
+    public String fieldConfigSchemeName;
+    @JsonProperty("searcherName")
+    public String searcherName;
+    @JsonProperty("relatedProjects")
+    public List<Map> relatedProjects;
+    @JsonProperty("isAllProjects")
+    public Boolean isAllProjects;
+    @JsonProperty("customTemplate")
+    public Object customTemplate;
+    @JsonProperty("modelTemplate")
+    public String modelTemplate;
+    @JsonProperty("name")
+    public String name;
+    @JsonProperty("desc")
+    public Object desc;
+    @JsonProperty("FIELD_PREVIEW_ISSUE")
+    public Object fieldPreviewIssue;
+    @JsonProperty("FIELD_SCRIPT_FILE_OR_SCRIPT")
+    @JsonAlias("CONFIGURATION_SCRIPT")
+    public Map fieldScriptFileOrScript;
+    @JsonProperty("FIELD_IS_MULTIPLE")
+    public boolean fieldIsMultiple;
+    @JsonProperty("canned-script")
+    public String cannedScript;
+    @JsonProperty("TRANSITION_STATE")
+    public String transitionState //Used for "Date of First Transition" fields
+
+    @JsonProperty("SEARCH_FIELDS")
+    public List<String> searchFields; //Used for "Issue Picker" fields
+    @JsonProperty("FIELD_PLACEHOLDER")
+    public String fieldPlaceholder; //Used for "Issue Picker" fields
+    @JsonProperty("currentJql")
+    public String currentJql; //Used for "Issue Picker" fields
+
+    @JsonProperty("FIELD_TIMES_IN_STATUS")
+    public ArrayList<String> fieldTimesInStatus; //Used for "No. of Times In Status" fields
+
+    @JsonProperty("FIELD_PARENT_ISSUE_EXTRACTORS")
+    public ArrayList<String> fieldParentIssueExtractors; //Used for "Show parent issue in hierarchy" fields
+    @JsonProperty("FIELD_TARGET_ISSUE_TYPE")
+    public String fieldTargetIssueType; //Used for "Show parent issue in hierarchy" fields
+
+    @JsonProperty("FIELD_CONN_NAME")
+    public String fieldConnName; //Used for "Database Picker" fields
+    @JsonProperty("VALIDATION_SQL")
+    public String validationSQL; //Used for "Database Picker" fields
+    @JsonProperty("SEARCH_SQL")
+    public String searchSQL; //Used for "Database Picker" fields
+
+
+
+    @JsonIgnore
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
+
+    @JsonIgnore()
+    JiraInstanceManagerRest jiraInstance
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    @JsonSetter("FIELD_IS_MULTIPLE")
+    public void setFieldIsMultiple(String onOrOff) {
+        fieldIsMultiple = (onOrOff == "on")
+    }
+
+    String toString() {
+        return "$name ($customFieldId)"
+    }
+
+
+    static ArrayList<ScriptFieldBean> getScriptFields(JiraInstanceManagerRest jim) {
+
+        Cookies cookies = jim.acquireWebSudoCookies()
+        HttpResponse response = jim.unirest.get("/rest/scriptrunner-jira/latest/scriptfields?").cookie(cookies).asObject(new GenericType<ArrayList<Map>>() {
+        })
+
+        assert response.status == 200: "Error getting ScriptFields from " + jim.unirest.config().defaultBaseUrl
+        ArrayList<Map> rawFields = response.body
+
+        ArrayList<ScriptFieldBean> scriptFieldBeans = objectMapper.convertValue(rawFields, new TypeReference<ArrayList<ScriptFieldBean>>() {
+        })
+        scriptFieldBeans.each { it.jiraInstance = jim }
+
+        return scriptFieldBeans
+    }
+
+    boolean isUsingInlineScript() {
+        return fieldScriptFileOrScript?.script
+    }
+
+    boolean isUsingScriptFile() {
+        return fieldScriptFileOrScript?.scriptPath
+    }
+
+    String getScriptBody() {
+
+        if (usingInlineScript) {
+            return fieldScriptFileOrScript.script
+        } else if (usingScriptFile) {
+
+            String body = jiraInstance.getScriptrunnerFile(fieldScriptFileOrScript?.scriptPath?.toString())
+            assert body != "": "Error getting script body for script:" + fieldScriptFileOrScript?.scriptPath
+
+            return body
+
+        }else if (cannedScript.endsWith("DateOfFirstTransitionScriptField")) {
+            log.debug("Date oF First Transition fields dont have a script body, only transitionState parameter")
+            return ""
+        }else if (cannedScript.endsWith("NoOfTimesInStatusScriptField")) {
+            log.debug("No. of Times In Status fields dont have a script body, only fieldTimesInStatus parameter")
+            return ""
+        }else if (cannedScript.endsWith("ParentIssueScriptField")) {
+            log.debug("Show parent issue in hierarchy fields dont have a script body, only fieldParentIssueExtractors and fieldTargetIssueType parameter")
+            return ""
+        }else if (cannedScript.endsWith("TimeOfLastStatusChangeScriptField")) {
+            log.debug("Time of Last Status Change fields dont have a script body")
+            return ""
+        }else if (cannedScript.endsWith("DbPickerCannedField")) {
+            log.debug("Database Picker Fields do not require Script Body")
+            return ""
+        }else if (cannedScript.endsWith("IssuePickerCannedFieldConfig")) {
+            log.debug("Issue Picker Fields do not require Script Body")
+            return ""
+        }
+
+        throw new InputMismatchException("Could not determine ScriptBody for ScriptField: ${this.toString()} ")
+
+
+    }
+
+    /**
+     * Get the last 15 executions of the script, equivalent of clicking the link in the History column in SR/Fields
+     * @return
+     */
+    ArrayList<ScriptFieldExecution> getExecutions() {
+
+        HttpResponse<ArrayList<Map>> rawResponse = jiraInstance.unirest.get("/rest/scriptrunner/latest/diagnostics/results?functionId=$fieldConfigurationSchemeId").asObject(new GenericType<ArrayList<Map>>() {})
+        assert rawResponse.status == 200 : "Error getting execution history for $this"
+        ArrayList<Map> rawExecutions = rawResponse.body
+        rawExecutions.each {
+            it.payload = objectMapper.readValue(it.payload.toString(), new TypeReference<Map>() {})
+        }
+        ArrayList<ScriptFieldExecution> executions = objectMapper.convertValue(rawExecutions, new TypeReference<ArrayList<ScriptFieldExecution>>() {})
+
+        return executions
+
+
+    }
+
+
+    static class ScriptFieldExecution {
+
+        @JsonProperty("key")
+        String key
+        @JsonProperty("created")
+        long created
+        @JsonProperty("cpuTime")
+        long cpuTime
+        @JsonProperty("millisecondsTaken")
+        long millisecondsTaken
+        @JsonProperty("exception")
+        String exception
+        @JsonProperty("payload")
+        Map payload
+        @JsonProperty("log")
+        String log
+
+        @JsonIgnore
+        private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
+
+        @JsonAnyGetter
+        public Map<String, Object> getAdditionalProperties() {
+            return this.additionalProperties;
+        }
+
+        @JsonAnySetter
+        public void setAdditionalProperty(String name, Object value) {
+            this.additionalProperties.put(name, value);
+        }
+
+
+    }
+
+
+}

--- a/src/tests/groovy/com/eficode/atlassian/jiraInstanceManager/JiraInstanceManagerRestSpec.groovy
+++ b/src/tests/groovy/com/eficode/atlassian/jiraInstanceManager/JiraInstanceManagerRestSpec.groovy
@@ -1,7 +1,9 @@
 package com.eficode.atlassian.jiraInstanceManager
 
+import com.eficode.atlassian.jiraInstanceManager.beans.AssetFieldBean
 import com.eficode.atlassian.jiraInstanceManager.beans.IssueBean
 import com.eficode.atlassian.jiraInstanceManager.beans.JiraApp
+import com.eficode.atlassian.jiraInstanceManager.beans.FieldBean
 import com.eficode.atlassian.jiraInstanceManager.beans.MarketplaceApp
 import com.eficode.atlassian.jiraInstanceManager.beans.ObjectSchemaBean
 import com.eficode.atlassian.jiraInstanceManager.beans.ProjectBean
@@ -219,10 +221,10 @@ class JiraInstanceManagerRestSpec extends Specification {
 
 
         [
-                "com/spoc/subSubFile.groovy" : "log.info(\"com/spoc/subSubFile.groovy\")",
-                "rootFile.groovy" : "log.info(\"rootFile.groovy\")",
-                "com/subFile.groovy" : "log.info(\"com/subFile.groovy\")",
-        ].each {path, content ->
+                "com/spoc/subSubFile.groovy": "log.info(\"com/spoc/subSubFile.groovy\")",
+                "rootFile.groovy"           : "log.info(\"rootFile.groovy\")",
+                "com/subFile.groovy"        : "log.info(\"com/subFile.groovy\")",
+        ].each { path, content ->
 
             String fileRelPath = path.contains("/") ? path.substring(0, path.lastIndexOf("/")) : ""
 
@@ -230,14 +232,14 @@ class JiraInstanceManagerRestSpec extends Specification {
                 new File(rootDir, fileRelPath).mkdirs()
             }
 
-            File newFile = new File(rootDir,path)
-            assert newFile.createNewFile() : "Error creating file:" + path
+            File newFile = new File(rootDir, path)
+            assert newFile.createNewFile(): "Error creating file:" + path
             newFile.text = content
             files += newFile
         }
 
 
-        return [(rootDir) : files]
+        return [(rootDir): files]
     }
 
     def "Test updateScriptrunnerFiles with recursive files"() {
@@ -248,7 +250,7 @@ class JiraInstanceManagerRestSpec extends Specification {
 
         Map<File, ArrayList<File>> sampleFilesMap = createSampleGroovyFiles()
         File localSampleRoot = sampleFilesMap.keySet().first()
-        ArrayList<File>localSampleFiles = sampleFilesMap.values().first()
+        ArrayList<File> localSampleFiles = sampleFilesMap.values().first()
         Map<String, String> uploadParameters = [:]
 
         localSampleFiles.each {
@@ -258,32 +260,29 @@ class JiraInstanceManagerRestSpec extends Specification {
 
         when: "Using a map with recursive files"
 
-        assert jim.updateScriptrunnerFiles([(localSampleRoot.canonicalPath) : "/"]) : "Error updating ScriptRunner files"
+        assert jim.updateScriptrunnerFiles([(localSampleRoot.canonicalPath): "/"]): "Error updating ScriptRunner files"
 
         then: "SR should have the same directory structure"
         localSampleFiles.each {
-            assert jim.getScriptrunnerFile(localSampleRoot.relativePath(it)) : "Failed to receive uploaded file:" + localSampleRoot.relativePath(it)
+            assert jim.getScriptrunnerFile(localSampleRoot.relativePath(it)): "Failed to receive uploaded file:" + localSampleRoot.relativePath(it)
 
         }
 
         when: "Deleting the files"
         localSampleFiles.each {
-            assert jim.deleteScriptrunnerFile(localSampleRoot.relativePath(it)) : "Failed to receive uploaded file:" + localSampleRoot.relativePath(it)
+            assert jim.deleteScriptrunnerFile(localSampleRoot.relativePath(it)): "Failed to receive uploaded file:" + localSampleRoot.relativePath(it)
 
         }
         then: "SR should no longer return them"
         localSampleFiles.each {
-            assert !jim.getScriptrunnerFile(localSampleRoot.relativePath(it)) : "Failed to receive uploaded file:" + localSampleRoot.relativePath(it)
+            assert !jim.getScriptrunnerFile(localSampleRoot.relativePath(it)): "Failed to receive uploaded file:" + localSampleRoot.relativePath(it)
 
         }
 
 
-
-
         cleanup:
 
-        assert localSampleRoot.deleteDir() : "Error cleaning up sample groovy files:" + localSampleRoot.canonicalPath
-
+        assert localSampleRoot.deleteDir(): "Error cleaning up sample groovy files:" + localSampleRoot.canonicalPath
 
 
     }
@@ -323,33 +322,33 @@ class JiraInstanceManagerRestSpec extends Specification {
         String jobCron = "0 0 22 ? * SAT"
         String userKey = "JIRAUSER10000"
 
-        assert jira.updateScriptrunnerFile("log.warn(\"test\")", jobFile) : "Error creating SR Job File"
+        assert jira.updateScriptrunnerFile("log.warn(\"test\")", jobFile): "Error creating SR Job File"
 
         assert installSr(srVersionNumber): "Error installing SR version:" + srVersionNumber
         log.info("\tUsing SR version:" + srVersionNumber)
         sleep(1500)//Wait for sr to detect file changes
 
 
-        when:"Creating SR job"
+        when: "Creating SR job"
         log.info("\tCreating SR Job")
-        log.info("\t"*2 + "Job Note:" + jobNote)
-        log.info("\t"*2 + "File:" + jobFile)
-        log.info("\t"*2 + "Cron:" + jobCron)
+        log.info("\t" * 2 + "Job Note:" + jobNote)
+        log.info("\t" * 2 + "File:" + jobFile)
+        log.info("\t" * 2 + "Cron:" + jobCron)
 
         SrJob srJob = jira.createSrJob(jobNote, userKey, jobCron, jobFile)
         log.info("\tCreated job:" + srJob?.id)
 
-        then:"Job should be created and listable"
+        then: "Job should be created and listable"
         srJob
-        jira.getSrJobs().find {it.id == srJob.id  && it.fieldJobCode.scriptPath == jobFile && it.fieldInterval == jobCron}
-        log.info("\t"*2 + "Job was successfully created and is returned when requested")
+        jira.getSrJobs().find { it.id == srJob.id && it.fieldJobCode.scriptPath == jobFile && it.fieldInterval == jobCron }
+        log.info("\t" * 2 + "Job was successfully created and is returned when requested")
 
         when: "Deleting the job"
         log.info("\tDeleting SR Job:" + srJob.id)
         assert jira.deleteSrJob(srJob.id): "Error deleting job"
 
         then:
-        assert jira.getSrJobs().find {it.id == srJob.id} == null : "Job could still be found after deletion"
+        assert jira.getSrJobs().find { it.id == srJob.id } == null: "Job could still be found after deletion"
 
 
         cleanup:
@@ -529,8 +528,8 @@ class JiraInstanceManagerRestSpec extends Specification {
         spockMethodOut = jira.runSpockTestV6("com.eficode.atlassian.jiraInstanceManager.jiraLocalScripts", "JiraLocalSpockTest", "A successful test in JiraLocalSpockTest")
 
         then: "The new test should be run when running a package test, but not when running the old class and method tests"
-        assert spockPackageOut.passedMethods == ["A successful test in JiraLocalSpockTest", "A successful test in JiraLocalSubSpockTest"] : "The spock package run did not run both the expected tests"
-        assert spockPackageOut.failedMethods == [:] : "The spock package run returned failed methods"
+        assert spockPackageOut.passedMethods == ["A successful test in JiraLocalSpockTest", "A successful test in JiraLocalSubSpockTest"]: "The spock package run did not run both the expected tests"
+        assert spockPackageOut.failedMethods == [:]: "The spock package run returned failed methods"
         assert spockPackageOut.ignoredMethods == []: "The spock package run returned ignored methods"
         assert spockPackageOut != spockClassOut: "The spock class run not be the same as the package run"
         assert spockClassOut == spockMethodOut: "The spock class and method run should be the same"
@@ -789,7 +788,7 @@ class JiraInstanceManagerRestSpec extends Specification {
         JiraInstanceManagerRest jira = new JiraInstanceManagerRest(baseUrl)
         jira.acquireWebSudoCookies()
 
-        String projectName = "Spoc Src Schema"
+        String projectName = "Spoc Src FieldSchema"
         String projectKey = jira.getAvailableProjectKey("SSS")
 
         ArrayList<Integer> preExistingSchemaIds = jira.getInsightSchemas().id
@@ -804,7 +803,7 @@ class JiraInstanceManagerRestSpec extends Specification {
         assert resultMap.schema
         assert !preExistingSchemaIds.contains(resultMap.schema.id as int)
         assert jira.projects.find { it.projectId == resultMap.project.projectId }: "getProjects() could not find project"
-        log.info("\tSchema and project successfully created")
+        log.info("\tFieldSchema and project successfully created")
 
 
         cleanup:
@@ -822,7 +821,7 @@ class JiraInstanceManagerRestSpec extends Specification {
         JiraInstanceManagerRest jira = getJiraInstanceManagerRest()
         jira.acquireWebSudoCookies()
 
-        String srcSchemaName = "Spoc Src Schema"
+        String srcSchemaName = "Spoc Src FieldSchema"
         String srcSchemaKey = "SSS"
         String srcSchemaTemplate = "hr"
         log.info("\tWill first create a new schema")
@@ -841,7 +840,7 @@ class JiraInstanceManagerRestSpec extends Specification {
 
                 ]).asJson().body.object.toMap()
 
-        log.info("\tSchema created with status ${sampleSchemaMap.status} and Id: " + sampleSchemaMap.id)
+        log.info("\tFieldSchema created with status ${sampleSchemaMap.status} and Id: " + sampleSchemaMap.id)
         assert sampleSchemaMap.status == "Ok", "Error creating sample schema"
 
         when: "Exporting the new sample schema"
@@ -910,6 +909,125 @@ class JiraInstanceManagerRestSpec extends Specification {
     }
 
 
+    def "Test Asset Field Crud"() {
+
+        setup: "Instantiate JiraInstanceManager"
+
+        log.info("Will test export and import of insight object schemas")
+
+        JiraInstanceManagerRest jim = getJiraInstanceManagerRest()
+        jim.setProxy("127.0.0.1", 8081)
+
+        if (!jim.projects.find { it.projectName == "Asset Field Crud" }) {
+
+            jim.createJsmProjectWithSampleData("Asset Field Crud", "ASSFCRUD")
+        }
+
+        ArrayList<FieldBean.FieldType> assetFieldTypes = jim.getFieldTypes().findAll {it.key.startsWith("com.riadalabs.jira.plugins.insight")}
+
+        expect:
+
+        assetFieldTypes.each {assetFieldType ->
+
+
+            String fieldPrefix = System.currentTimeMillis().toString()[-5..-1]
+
+
+            FieldBean newField = jim.createCustomfield(fieldPrefix + "-" + assetFieldType.name, assetFieldType.searchers.first(), assetFieldType.key, "Field type: ${assetFieldType.name}")
+
+            assert  newField.class == AssetFieldBean : "createCustomfield() did not return an AssetFieldBean when creating an asset field"
+
+            AssetFieldBean newAssetField = newField as AssetFieldBean
+
+            assert newAssetField.getConfigSchemeIds().size() == 1 : "getConfigSchemeIds() did not return the expected number of schema ids"
+
+            assert newAssetField.deleteCustomField()
+
+        }
+
+
+    }
+
+    def "Test Field Crud"() {
+
+        setup: "Instantiate JiraInstanceManager"
+
+        log.info("Will test export and import of insight object schemas")
+
+        JiraInstanceManagerRest jim = getJiraInstanceManagerRest()
+        //jim.setProxy("127.0.0.1", 8081)
+
+        if (!jim.projects.find { it.projectName == "Field Crud" }) {
+            jim.createJsmProjectWithSampleData("Field Crud", "FIELDCRUD")
+        }
+
+
+        when: "When getting all fields"
+        ArrayList<FieldBean> jiraFieldBeans = FieldBean.getFields(jim)
+
+
+        then: "Custom and system fields should be returned. FieldTypes should be found, JSM CAB field should have been created with global project and issueType scope"
+        jiraFieldBeans.any { it.custom }
+        jiraFieldBeans.any { it.custom == false }
+        jiraFieldBeans.any { it.name == "Key" && it.id == "issuekey" }
+        jiraFieldBeans.size() > 10
+        FieldBean.FieldType.getFieldTypes(jim).size() > 35
+        FieldBean.getFields(jim).id.sort() == jim.getFields().id.sort()
+        assert jiraFieldBeans.find { it.name == "CAB" }.getFieldProjects().projectId == jim.getProjects().projectId: "Expected CAB field to be applied to all projects"
+        assert jiraFieldBeans.find { it.name == "CAB" }.getFieldIssueTypes().id == jim.getIssueTypes().id: "Expected CAB field applied to all issue types"
+
+
+        expect: "Creation of fields with global/specific issueType/project of all fieldTypes and searchers, to work."
+        log.info("Testing creation of fields")
+        jim.getFieldTypes().each { fieldType ->
+            String fieldTypKey = fieldType.key
+            log.info("\tTesting creation of field type:" + fieldTypKey)
+            fieldType.searchers.each { searcherKey ->
+                log.info("\t" * 2 + "Creating using Searcher:" + searcherKey)
+                String fieldPrefix = System.currentTimeMillis().toString()[-5..-1]
+                ArrayList<String> projectIds = jim.getProjects().projectId
+                projectIds.add(null)
+                projectIds.shuffle()
+                projectIds = [projectIds.first()]
+
+                log.info("\t" * 3 + "Adding to project:" + (projectIds == [null] ? " Global (all Projects)" : projectIds.join(",")))
+
+                ArrayList<String> issueTypeIds = jim.getIssueTypes().id
+                issueTypeIds.add("-1")
+                issueTypeIds.shuffle()
+                issueTypeIds = [issueTypeIds.first()]
+                log.info("\t" * 3 + "Adding to IssueType:" + (issueTypeIds == ["-1"] ? " Global (all issueTypes)" : issueTypeIds.join(",")))
+
+
+                FieldBean newField = jim.createCustomfield(fieldPrefix + "-" + fieldType.name, searcherKey, fieldTypKey, "Field type: ${fieldType.name}, Project: $projectIds, IssueType: $issueTypeIds", projectIds, issueTypeIds)
+                log.info("\t" * 3 + "Created field:" + newField.toString())
+
+                if (projectIds == [null]) {
+                    assert newField.getFieldProjects(true).projectId == jim.getProjects().projectId: "Field ${newField.id} was setup as project-global but getFieldProjects(true) did not return all projects"
+
+                } else {
+                    assert projectIds.toString() == newField.getFieldProjects(true).projectId.toString(): "Field ${newField.id} was setup for specific projects ($projectIds) but getFieldProjects(true) did not return the expected projects"
+                }
+
+                if (issueTypeIds == ["-1"]) {
+                    assert newField.getFieldIssueTypes(true).id == jim.getIssueTypes(true).id: "Field ${newField.id} was setup as issueType-global but getIssueTypes(true) did not return all issueTypes"
+                } else {
+                    assert issueTypeIds.toString() == newField.getFieldIssueTypes(true).id.toString(): "Field ${newField.id} was setup for specific issueTypes ($issueTypeIds) but getFieldIssueTypes(true) did not return the expected issueTypes"
+                }
+
+                assert newField.getFieldType(true).key == fieldType.key: "Field ${newField.id} was suposed to be type ${fieldType.key}, but API returned ${newField.getFieldType(true).key}"
+                log.info("\t" * 3 + "Field was successfully created")
+
+                assert newField.deleteCustomField(): "Error deleting customfield " + newField.id
+                log.info("\t" * 3 + "Field was successfully deleted")
+
+            }
+        }
+
+
+    }
+
+
     String beanMapGenerator(Map map) {
         String out = ""
 
@@ -943,6 +1061,7 @@ class JiraInstanceManagerRestSpec extends Specification {
         String projectName = "JQL Test"
         String projectKey = "JQL"
         JiraInstanceManagerRest jira = getJiraInstanceManagerRest()
+
 
         ProjectBean projectBean = jira.createJsmProjectWithSampleData(projectName, projectKey)
 

--- a/src/tests/groovy/com/eficode/atlassian/jiraInstanceManager/examples/Identify Problematic Script Fields.groovy
+++ b/src/tests/groovy/com/eficode/atlassian/jiraInstanceManager/examples/Identify Problematic Script Fields.groovy
@@ -1,0 +1,235 @@
+// https://mvnrepository.com/artifact/org.apache.commons/commons-text
+@Grapes(
+        @Grab(group = 'org.apache.commons', module = 'commons-text', version = '1.10.0')
+)
+
+import com.eficode.atlassian.jiraInstanceManager.JiraInstanceManagerRest
+import com.eficode.atlassian.jiraInstanceManager.beans.FieldBean
+import com.eficode.atlassian.jiraInstanceManager.beans.ScriptFieldBean
+import com.eficode.atlassian.jiraInstanceManager.beans.ScriptFieldBean.ScriptFieldExecution
+import org.apache.commons.text.similarity.JaccardDistance
+import org.apache.commons.text.similarity.JaccardSimilarity
+import org.apache.commons.text.similarity.JaroWinklerDistance
+import org.apache.commons.text.similarity.JaroWinklerSimilarity
+import org.apache.commons.text.similarity.LevenshteinDistance
+import org.apache.commons.text.similarity.SimilarityScoreFrom
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.spockframework.runtime.condition.EditOperation
+import org.spockframework.runtime.condition.EditPathRenderer
+
+//TODO Get performance statics, check scripts that sleep for a long time and a looping while loop
+//TODO check if field hasnt been executed in X time
+//TODO check if field has been executed less than X times in $timeSpan
+//TODO Check if applied globally
+
+
+JiraInstanceManagerRest jim = new JiraInstanceManagerRest("http://jira.localhost:8080")
+jim.setProxy("127.0.0.1", 8081)
+
+jim.verifySsl = false
+
+double start = System.currentTimeMillis()
+ArrayList<ScriptFieldBean> scriptFieldBeans = jim.getScriptFields()
+ArrayList<ScriptFieldBeanReport> scriptFieldsReports = scriptFieldBeans.collect { new ScriptFieldBeanReport(it) }
+double stop = System.currentTimeMillis()
+
+
+
+String report = ScriptFieldBeanReport.toJiraMarkDown(scriptFieldsReports)
+//scriptFieldsReports.collect {it.toJiraMarkdown()}.join("\n")
+println(report)
+println("Duration: " + (stop - start).div(1000).toDouble().trunc(1) + "s")
+
+class ScriptFieldBeanReport {
+
+
+    ScriptFieldBean scriptFieldBean
+    static Logger log = LoggerFactory.getLogger(ScriptFieldBeanReport.class)
+
+    static final long executionTimeWarn = 1500
+    static final long executionTimeError = 3000
+    static final int scriptSimilarWarnPercent = 75
+
+    static final textSimilarity = new LevenshteinDistance()
+    //static final textSimilarity = new JaccardSimilarity()
+
+
+    ScriptFieldBeanReport(ScriptFieldBean scriptField) {
+        this.scriptFieldBean = scriptField
+    }
+
+    static String toJiraMarkDown(ArrayList<ScriptFieldBeanReport> reports) {
+
+
+        return reports.collect { it.toJiraMarkdown() }.join("\n") + getScriptSimilarityBlock(reports.scriptFieldBean) + footer
+
+    }
+
+    static String getScriptSimilarityBlock(ArrayList<ScriptFieldBean> fieldBeans) {
+
+        //Ignores fields that have no scriptBody
+
+        Map<ScriptFieldBean, String> fieldBodyMap = [:]
+        fieldBeans.each {
+            String scriptBody = it.scriptBody
+            if( scriptBody != "") {
+                fieldBodyMap.put(it, scriptBody)
+            }
+
+        }
+
+        Map<ScriptFieldBean, Map<ScriptFieldBean, String>> similarityMatrix = [:]
+
+        fieldBodyMap.each { firstField, firstFieldBody ->
+            Map<ScriptFieldBean, String> bodySimilarity = [:]
+
+            fieldBodyMap.each { secondField, secondFieldBody ->
+
+
+                try {
+                    if (firstFieldBody == "" && secondFieldBody == "") {
+                        bodySimilarity.put(secondField, "null")
+                    } else {
+                        Integer charsThatDiff = textSimilarity.apply(firstFieldBody, secondFieldBody)
+                        double similarityPercent = 100 - ((charsThatDiff / [firstFieldBody.length(), secondFieldBody.length()].max())) * 100l
+                        similarityPercent = similarityPercent.trunc(1)
+
+
+
+                        bodySimilarity.put(secondField, similarityPercent >= scriptSimilarWarnPercent ? "{color:red}$similarityPercent%{color}" : similarityPercent + "%")
+                    }
+
+                } catch (ignored) {
+                    log.warn("Error determening Script Similarity between ${firstField} and $secondField")
+                    bodySimilarity.put(secondField, "{color:red}Error{color}")
+                }
+
+
+            }
+
+            if (bodySimilarity.size() > 0) {
+                similarityMatrix.put(firstField, bodySimilarity)
+            }
+
+
+        }
+
+        String tableBody = "|| ||" + similarityMatrix.keySet().customFieldId.sort().collect { it + "||" }.join() + "\n"
+
+        similarityMatrix.sort { it.key.customFieldId }.each { rowFieldBean, columnBeans ->
+
+
+            tableBody += "||" + rowFieldBean.customFieldId + "|" + columnBeans.sort { it.key.customFieldId }.values().collect { it + "|" }.join() + "\n"
+        }
+
+        String header = "\\\\\n" +
+                "----\n" +
+                "h2. Script Similarity Matrix\n" +
+                "The table below aims to help you find scripts that are very similar and that could perhaps be combined\n" +
+                "The Row and Colum headers represents CustomFiled ID´s while the cell is a percentage of how similar the scripts are between the fields\n"
+
+        return header + tableBody
+
+    }
+
+    static String getFooter() {
+
+        return "\\\\\n" +
+                "----\n" +
+                "h2. Background/Information\n" +
+                "[May Lock Index - JQL Searches in Script Fields |https://docs.adaptavist.com/sr4js/latest/features/script-fields/script-field-tips]\n" +
+                "[Uses Stattable Searcher |https://docs.adaptavist.com/sr4js/latest/features/script-fields]\n" +
+                "[Uses Natural Searcher |https://marketplace.atlassian.com/apps/1210967/natural-searchers-for-jira?hosting=datacenter&tab=overview] Similar to Stattable searchers but uses third party App\n"
+
+    }
+
+    String toJiraMarkdown() {
+
+        return "h2. $scriptFieldBean\n" +
+                "*May cause index lockup:*\t" + mayCauseIndexLock() + " " + (mayCauseIndexLock() ? "(!)" : "(/)") + "\n" +
+                "*Uses Stattable Searcher:*\t" + usesStattableSearcher() + " " + (usesStattableSearcher() ? "(!)" : "(/)") + "\n" +
+                "*Uses Natural Searcher:*\t" + usesNaturalSearcher() + " " + (usesNaturalSearcher() ? "(!)" : "(/)") + "\n" +
+                executionHistoryBlock + "\n"
+    }
+
+
+    String getExecutionHistoryBlock() {
+
+        ArrayList<ScriptFieldExecution> fieldExecutions = scriptFieldBean.getExecutions()
+
+        String blockBody = "h3. Field Execution History (last ${fieldExecutions.size()})\n"
+        if (fieldExecutions.empty) {
+            blockBody += "*Field has never been executed:* (!)\n"
+            return blockBody
+        }
+
+        long maxExecutionTime = (fieldExecutions.millisecondsTaken.toList() + (fieldExecutions.cpuTime.collect { it / 1000000 }) as List).max() as Long
+        long avgExecutionTime = (fieldExecutions.millisecondsTaken.toList() + (fieldExecutions.cpuTime.collect { it / 1000000 }) as List).average() as Long
+        int failures = fieldExecutions.exception.findAll { it != null }.size()
+
+        ArrayList<String> projectKeys = fieldExecutions.payload.issue.collect { it.toString().substring(0, it.toString().indexOf("-")) }.unique()
+
+        ArrayList<Long> executionTimestamps = fieldExecutions.created.sort()
+        ArrayList<Long> timeBetweenExecutions = []
+        executionTimestamps.eachWithIndex { long timeStamp, int i ->
+            if (fieldExecutions.created.size() > i && i > 0) {
+                long lastExecution = executionTimestamps[i - 1]
+                timeBetweenExecutions += timeStamp - lastExecution
+            }
+        }
+        long nrOfCloseExecutions = timeBetweenExecutions.findAll { it < 2000 }.size()
+        int percentOfCloseExecutions = ((nrOfCloseExecutions / fieldExecutions.size()) * 100).toInteger()
+
+
+        blockBody += "*Max execution time:* " + maxExecutionTime + "ms " + (maxExecutionTime > executionTimeError ? "(x)" : (maxExecutionTime > executionTimeWarn ? "(!)" : "(/)")) + "\n"
+        blockBody += "*Average execution time:* " + avgExecutionTime + "ms " + (avgExecutionTime > executionTimeError ? "(x)" : (avgExecutionTime > executionTimeWarn ? "(!)" : "(/)")) + "\n"
+        blockBody += "*Failures:* " + failures + " (${((failures / fieldExecutions.size()) * 100).toInteger()}%) " + (failures ? "(!)" : "(/)") + "\n"
+        blockBody += "*Rendered in projects:* " + projectKeys.join(", ") + "\n"
+        blockBody += "*Number of executions < 2 Sec apart:* " + nrOfCloseExecutions + " (${percentOfCloseExecutions}%)" + (percentOfCloseExecutions > 30 ? "(!)" : "(/)")
+        return blockBody
+
+    }
+
+    //https://docs.adaptavist.com/sr4js/latest/features/script-fields
+    boolean usesStattableSearcher() {
+
+        return scriptFieldBean.searcherName?.containsIgnoreCase("Stattable")
+    }
+
+    boolean usesNaturalSearcher() {
+
+        return scriptFieldBean.searcherName?.containsIgnoreCase("(natural)")
+    }
+
+
+    //https://docs.adaptavist.com/sr4js/latest/features/script-fields/script-field-tips
+    boolean mayCauseIndexLock() {
+
+        String scriptBody = scriptFieldBean.getScriptBody()
+
+        if (scriptBody == "") {
+            return false
+        }
+
+        ArrayList<String> jqlIndicators = ["JqlQueryParser", "SearchProvider", "SearchQuery", "JqlQueryBuilder", "SearchService", "Issues.count(", "Issues.search("]
+        if (jqlIndicators.any { jqlIndicator -> scriptBody.containsIgnoreCase(jqlIndicator) }) {
+            log.info(scriptFieldBean.toString() + " looks to be using JQL, checking if it handles the Index Correctly")
+
+            if (scriptBody.containsIgnoreCase("isIndexAvailable")) {
+                log.info("\tField appears to correctly check if index is available")
+                return false
+            } else {
+                log.warn("\t$scriptFieldBean does not appear to check if index is available")
+                return true
+            }
+
+
+        } else {
+            return false
+        }
+
+    }
+
+}
+


### PR DESCRIPTION
JiraInstanceManager

Added setProxy(), setVerifySsl()
Added installScriptRunner(), a new helper method for installing SR
getProjects() now defaults to using cached projects Potentially breaking
Added createCustomField(), This method should be considered beta and is subject to change
Added getIssueTypes(), getScriptedFields()

POM

Bumped unirest to 3.14.2
Bumped dev stack to 2.3.5