### PR TITLE
Added waitinforXToBeResponsive, added overload to installApp

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.eficode.atlassian</groupId>
     <artifactId>jirainstancemanager</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.2-SNAPSHOT</version>
     <description>A groovy library for interacting with Jira REST API.</description>
 
     <profiles>


### PR DESCRIPTION
 * acquireWebSudoCookies improved error handling when a cookie could not be acquired.
 * installApp() a new overloaded method allowing installing of Apps using MarketplaceApp.Version
 * waitForJiraToBeResponsive(), waitForSrToBeResponsive() added two methods for waiting for JIRA to become responsive after a restart
* Bumped to 2.0.2