### PR TITLE
Minor fixes to mvn tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -169,6 +169,9 @@
                         <include>**/*Test.java</include>
                         <include>**/*Spec.java</include>
                     </includes>
+                    <excludes>
+                        <exclude>**/JiraLocalFailedSpockTest.java</exclude>
+                    </excludes>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
 * Updated so that mvn doesn't test the intentional failing spock test JiraLocalFailedSpockTest. This test is intended to be run inside of JIRA